### PR TITLE
JSON version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 RadeonOpenCompute/rocm-cmake@cdd0f632b3a65bd4411593bb827eb664e25c80bc --build
 # ROCmSoftwarePlatform/MIOpen@9b2d37f9f1e4b5492ef8256cf8168363ca5fd2da 
-nlohmann/json
+nlohmann/json@v3.10.4
 #ROCmSoftwarePlatform/rocBLAS@9790a8658341bc665c11c311129ad0dfc533d5c4
 


### PR DESCRIPTION
Couldnt quite figure out how to workaround the JSON 3.10.5 version filesystem issues, so setting back to an older version works.

Just to keep this in the records somewhere, we need this compile flag set: -lstdc++fs. I was not able to set it correctly in the Cmake file, but i was able to compile locally using it and it worked.