### PR TITLE
PerfCompile and PerfEval changes

### DIFF
--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -508,7 +508,8 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
 
                 if(miopen::md5(hsaco) == md5_sum)
                 {
-                    try{
+                    try
+                    {
                         auto p = miopen::Program{kernel_file, hsaco};
                         std::cerr << "Add Program: " << kernel_file << "; args: " << comp_opts
                                   << std::endl;
@@ -1342,7 +1343,6 @@ int ConvFin<Tgpu, Tref>::SearchPreCompiledKernels()
             bool retvalue;
             // to extract solver id ,context,solution
             auto process_solver = [&]() -> bool {
-
                 res_item["solver_id"] = solver_id.ToString();
                 const auto s          = solver_id.GetSolver();
                 if(s.IsEmpty())


### PR DESCRIPTION
-allow non-tunable solvers in fin perf to allow time recording for find db 
-identify tunable / non-tunable solvers
-error catch for adding programs during eval
-skip fused solvers in perf eval