### PR TITLE
Continue PerfEval without kernels

### DIFF
--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -543,13 +543,6 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
             if(!s.IsTunable())
                 res_item["tunable"] = false;
 
-            // eg when ConvOclDirectFwd has no kernels FindSolution memory faults
-            if(s.IsTunable() and kinder["kernel_objects"].empty())
-            {
-                res_item["reason"] = "No Kernels";
-                return false;
-            }
-
             std::cerr << solver_name << " is applicable" << std::endl;
             // Get the binary
             std::cerr << "loading binaries from fin input" << std::endl;


### PR DESCRIPTION
Allow perf eval to continue without precompiled kernels.
This is a workaround to evaluate legacy solvers.