### PR TITLE
Changes cmake file at root to use C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 ############################################################
-# require C++14
-add_compile_options(-std=c++14)
+# require C++17
+add_compile_options(-std=c++17)
 
 ############################################################
 # OPTION - MIOpen Backend

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -20,6 +20,7 @@ list(APPEND GTEST_CMAKE_CXX_FLAGS
      -Wno-unused-member-function
      -Wno-comma
      -Wno-old-style-cast
+     -Wno-deprecated
 )
 message(STATUS "Suppressing googltest warnings with flags: ${GTEST_CMAKE_CXX_FLAGS}")
 

--- a/src/include/fin.hpp
+++ b/src/include/fin.hpp
@@ -153,8 +153,8 @@ class BaseFin
             {
                 auto p = handle.LoadProgram(kern.kernel_file, kern.comp_options, false, "");
                 hsaco  = p.IsCodeObjectInMemory()
-                             ? p.GetCodeObjectBlob()
-                             : miopen::LoadFile(p.GetCodeObjectPathname().string());
+                            ? p.GetCodeObjectBlob()
+                            : miopen::LoadFile(p.GetCodeObjectPathname().string());
                 if(hsaco.empty())
                 {
                     std::cerr << "Got empty code object" << std::endl;


### PR DESCRIPTION
MIOpen uses C++17. Fin uses MIOpen interanals and failes to be built on any actual C++17 features in MIOpen headers encountered.
This includes fixes to errors from switching standard and a workaround for googletest just like in MIOpen. Googletest has fixed deprecation warnings in master, but not yet released a version containing the changes.