### PR TITLE
Removed uses of INT8x4 datatype

### DIFF
--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -113,7 +113,7 @@ class ConvFin : public BaseFin
     std::vector<size_t> GetOutputTensorLengths() const;
     miopenDataType_t GetOutputType() const
     {
-        return (data_type == miopenInt8 || data_type == miopenInt8x4) ? miopenFloat : data_type;
+        return (data_type == miopenInt8) ? miopenFloat : data_type;
     }
     miopen::conv::Direction GetDirection() const;
 
@@ -2146,8 +2146,7 @@ std::vector<size_t> ConvFin<Tgpu, Tref>::GetOutputTensorLengths() const
 template <typename Tgpu, typename Tref>
 bool ConvFin<Tgpu, Tref>::IsInputTensorTransform() const
 {
-    return (data_type == miopenInt8 && int(command["in_channels"]) % 4 != 0) ||
-           data_type == miopenInt8x4;
+    return (data_type == miopenInt8 && int(command["in_channels"]) % 4 != 0);
 }
 
 namespace detail {
@@ -2313,7 +2312,7 @@ int ConvFin<Tgpu, Tref>::FillBuffers()
     throw std::runtime_error("Unable to fill buffers with NOGPU backend");
 #else
     // TODO: Do we need to initialized tensors ?
-    auto is_int8 = (data_type == miopenInt8 || data_type == miopenInt8x4);
+    auto is_int8 = (data_type == miopenInt8);
     srand(0);
 
     inputTensor.FillBuffer(std::bind(init_in<Tgpu>, is_int8, std::placeholders::_1));


### PR DESCRIPTION
This is necessary prerequisite to fully remove legacy INT8x4 support from MIOpen.