### PR TITLE
Error handling for missing or corrupt binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Use miopen ci base image
-ARG BASEIMAGE=rocm/miopen:ci_441044
+ARG BASEIMAGE=rocm/miopen:ci_f6608b
 
 #FROM ubuntu:20.04
 FROM $BASEIMAGE

--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -541,7 +541,16 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
                 const auto md5_sum       = kernel_obj["md5_sum"];
                 const auto encoded_hsaco = kernel_obj["blob"];
                 const auto decoded_hsaco = base64_decode(encoded_hsaco);
-                const auto hsaco         = miopen::decompress(decoded_hsaco, size);
+                std::vector<char> hsaco;
+                try
+                {
+                    hsaco = miopen::decompress(decoded_hsaco, size);
+                }
+                catch(const std::exception& e)
+                {
+                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what() << std::endl;
+                    continue;
+                }
 
                 std::string kernel_file_no_ext = kernel_obj["kernel_file"];
                 std::string kernel_file        = kernel_file_no_ext + ".o";
@@ -576,10 +585,7 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
                 }
                 else
                 {
-                    res_item["reason"] = "Corrupt Binary";
-                    std::cerr << "Corrupt Binary Object" << std::endl;
-                    throw std::runtime_error("Corrupt binary object");
-                    return false;
+                    std::cerr << "Corrupt Binary Object, will try re-compiling" << std::endl;
                 }
             }
 
@@ -708,6 +714,7 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
             catch(const std::exception& e)
             {
                 res_item["reason"] = std::string("Invoker exception: ") + e.what();
+                std::cerr << res_item["reason"] << std::endl;
                 return false;
             }
 
@@ -826,7 +833,16 @@ int ConvFin<Tgpu, Tref>::MIOpenFindEval()
                 const auto md5_sum       = kernel_obj["md5_sum"];
                 const auto encoded_hsaco = kernel_obj["blob"];
                 const auto decoded_hsaco = base64_decode(encoded_hsaco);
-                const auto hsaco         = miopen::decompress(decoded_hsaco, size);
+                std::vector<char> hsaco;
+                try
+                {
+                    hsaco = miopen::decompress(decoded_hsaco, size);
+                }
+                catch(const std::exception& e)
+                {
+                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what() << std::endl;
+                    continue;
+                }
 
                 std::string kernel_file_no_ext = kernel_obj["kernel_file"];
                 std::string kernel_file        = kernel_file_no_ext + ".o";
@@ -854,9 +870,7 @@ int ConvFin<Tgpu, Tref>::MIOpenFindEval()
                 }
                 else
                 {
-                    std::cerr << "Corrupt Binary Object" << std::endl;
-                    throw std::runtime_error("Corrupt binary object");
-                    return false;
+                    std::cerr << "Corrupt Binary Object, will try re-compiling" << std::endl;
                 }
             }
 
@@ -955,7 +969,8 @@ int ConvFin<Tgpu, Tref>::MIOpenFindEval()
             }
             catch(const std::exception& e)
             {
-                res_item["reason"] = std::string("Invoker exeception: ") + e.what();
+                res_item["reason"] = std::string("Invoker exception: ") + e.what();
+                std::cerr << res_item["reason"] << std::endl;
                 return false;
             }
 
@@ -1139,7 +1154,8 @@ int ConvFin<Tgpu, Tref>::MIOpenFind()
             }
             catch(const std::exception& e)
             {
-                res_item["reason"] = std::string("Invoker exeception: ") + e.what();
+                res_item["reason"] = std::string("Invoker exception: ") + e.what();
+                std::cerr << res_item["reason"] << std::endl;
                 return false;
             }
 

--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -548,7 +548,8 @@ int ConvFin<Tgpu, Tref>::MIOpenPerfEval()
                 }
                 catch(const std::exception& e)
                 {
-                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what() << std::endl;
+                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what()
+                              << std::endl;
                     continue;
                 }
 
@@ -840,7 +841,8 @@ int ConvFin<Tgpu, Tref>::MIOpenFindEval()
                 }
                 catch(const std::exception& e)
                 {
-                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what() << std::endl;
+                    std::cerr << "Binary decompression failed, will try re-compiling: " << e.what()
+                              << std::endl;
                     continue;
                 }
 

--- a/src/include/fin.hpp
+++ b/src/include/fin.hpp
@@ -151,14 +151,24 @@ class BaseFin
             if(hsaco.empty())
             {
                 auto p = handle.LoadProgram(kern.kernel_file, kern.comp_options, "");
-                hsaco  = p.IsCodeObjectInMemory()
-                             ? p.GetCodeObjectBlob()
-                             : miopen::LoadFile(p.GetCodeObjectPathname().string());
-                if(hsaco.empty())
+
+
+                try
                 {
-                    std::cerr << "Got empty code object" << std::endl;
-                    throw std::runtime_error("Got empty code object");
+                    hsaco  = p.IsCodeObjectInMemory()
+                                 ? p.GetCodeObjectBlob()
+                                 : miopen::LoadFile(p.GetCodeObjectPathname().string());
+                    if(hsaco.empty())
+                    {
+                        throw std::runtime_error("Got empty code object");
+                    }
                 }
+                catch(const std::exception& e)
+                {
+                    std::cerr << "No code object, skipping: " << e.what() << std::endl;
+                    continue;
+                }
+
             }
             // Compress the blob
             auto md5_sum             = miopen::md5(hsaco);

--- a/src/include/fin.hpp
+++ b/src/include/fin.hpp
@@ -152,12 +152,11 @@ class BaseFin
             {
                 auto p = handle.LoadProgram(kern.kernel_file, kern.comp_options, "");
 
-
                 try
                 {
-                    hsaco  = p.IsCodeObjectInMemory()
-                                 ? p.GetCodeObjectBlob()
-                                 : miopen::LoadFile(p.GetCodeObjectPathname().string());
+                    hsaco = p.IsCodeObjectInMemory()
+                                ? p.GetCodeObjectBlob()
+                                : miopen::LoadFile(p.GetCodeObjectPathname().string());
                     if(hsaco.empty())
                     {
                         throw std::runtime_error("Got empty code object");
@@ -168,7 +167,6 @@ class BaseFin
                     std::cerr << "No code object, skipping: " << e.what() << std::endl;
                     continue;
                 }
-
             }
             // Compress the blob
             auto md5_sum             = miopen::md5(hsaco);


### PR DESCRIPTION
Detect binaries from json input which fails to decompress.
Does not stop perf or find evaluation from proceeding when kernel binary loading fails.
Error tolerance when failing to retrieve hsa object from miopen.