### PR TITLE
Improve finding half.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,8 @@ set(BOOST_COMPONENTS filesystem system)
 add_definitions(-DBOOST_ALL_NO_LIB=1)
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
-find_path(HALF_INCLUDE_DIR half.hpp)
+find_path(HALF_INCLUDE_DIR half.hpp HINTS ${CMAKE_INSTALL_PREFIX}/include ${CMAKE_INSTALL_PREFIX}/include/half )
+message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
 
 option( BUILD_SHARED_LIBS "Build as a shared library" ON )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ configure_file("${PROJECT_SOURCE_DIR}/src/include/config.h.in" "${PROJECT_BINARY
 include_directories(include "${PROJECT_BINARY_DIR}/src/include")
 add_executable(fin main.cpp fin.cpp base64.cpp)
 target_compile_definitions( fin PRIVATE -D__HIP_PLATFORM_HCC__=1 )
+target_include_directories(fin PRIVATE ${HALF_INCLUDE_DIR})
 target_link_libraries(fin MIOpen ${Boost_LIBRARIES} hip::host)
 target_link_libraries(fin ${CMAKE_THREAD_LIBS_INIT})
 if(rocblas_FOUND)

--- a/src/include/gpu_mem.hpp
+++ b/src/include/gpu_mem.hpp
@@ -27,11 +27,7 @@
 #ifndef GUARD_FIN_GPUMEM_HPP
 #define GUARD_FIN_GPUMEM_HPP
 
-#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
-#include <half/half.hpp>
-#else
 #include <half.hpp>
-#endif
 #include <algorithm>
 #include <cfloat>
 #include <cstdio>

--- a/src/include/tensor.hpp
+++ b/src/include/tensor.hpp
@@ -28,11 +28,7 @@
 #define GUARD_FIN_TENSOR_HPP
 
 #include <miopen/config.h>
-#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
-#include <half/half.hpp>
-#else
 #include <half.hpp>
-#endif
 #include <miopen/bfloat16.hpp>
 
 #include <gpu_mem.hpp>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,11 +31,7 @@
 #include "error.hpp"
 #include "fin.hpp"
 
-#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
-#include <half/half.hpp>
-#else
 #include <half.hpp>
-#endif
 #include <miopen/bfloat16.hpp>
 
 using half_float::half;


### PR DESCRIPTION
On Fedora, half.hpp is always installed to /usr/include, so using #include <half/half.h> will always fail.

So look for half.hpp and use its path to add the cpp flag -I <path-to-half.hpp>

Simplify the sources to only have #include <half.hpp>