### PR TITLE
Correct half include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 find_path(HALF_INCLUDE_DIR half.hpp HINTS ${CMAKE_INSTALL_PREFIX}/include ${CMAKE_INSTALL_PREFIX}/include/half )
 message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
+include_directories(${HALF_INCLUDE_DIR})
 
 option( BUILD_SHARED_LIBS "Build as a shared library" ON )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,6 @@ configure_file("${PROJECT_SOURCE_DIR}/src/include/config.h.in" "${PROJECT_BINARY
 include_directories(include "${PROJECT_BINARY_DIR}/src/include")
 add_executable(fin main.cpp fin.cpp base64.cpp)
 target_compile_definitions( fin PRIVATE -D__HIP_PLATFORM_HCC__=1 )
-target_include_directories(fin PRIVATE ${HALF_INCLUDE_DIR})
 target_link_libraries(fin MIOpen ${Boost_LIBRARIES} hip::host)
 target_link_libraries(fin ${CMAKE_THREAD_LIBS_INIT})
 if(rocblas_FOUND)


### PR DESCRIPTION
Tensor header files were not picking up half location during compilation. Expand scope of half include directory.