### PR TITLE
[MIFin] Replace Boost library usage with C++ standard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,6 @@
-################################################################################
-#
-# MIT License
-#
-# Copyright (c) 2020 Advanced Micro Devices, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-################################################################################
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required( VERSION 3.15 )
 
 # This has to be initialized before the project() command appears
@@ -156,11 +134,6 @@ if(CMAKE_CXX_COMPILER MATCHES ".*hcc")
         message(FATAL_ERROR "extractkernel not found")
     endif()
 endif()
-
-option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)
-set(BOOST_COMPONENTS filesystem system)
-add_definitions(-DBOOST_ALL_NO_LIB=1)
-find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 find_path(HALF_INCLUDE_DIR half.hpp HINTS ${CMAKE_INSTALL_PREFIX}
     PATH_SUFFIXES include include/half)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,28 +1,6 @@
-################################################################################
-# 
-# MIT License
-# 
-# Copyright (c) 2020 Advanced Micro Devices, Inc.
-# 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-# 
-################################################################################
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required( VERSION 3.15 )
 list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/hip /opt/rocm/hcc /opt/rocm/opencl)
 
@@ -31,7 +9,7 @@ configure_file("${PROJECT_SOURCE_DIR}/src/include/config.h.in" "${PROJECT_BINARY
 include_directories(include "${PROJECT_BINARY_DIR}/src/include")
 add_executable(fin main.cpp fin.cpp base64.cpp)
 target_compile_definitions( fin PRIVATE -D__HIP_PLATFORM_HCC__=1 )
-target_link_libraries(fin MIOpen ${Boost_LIBRARIES} hip::host)
+target_link_libraries(fin MIOpen hip::host)
 target_link_libraries(fin ${CMAKE_THREAD_LIBS_INIT})
 if(rocblas_FOUND)
     target_link_libraries( fin $<BUILD_INTERFACE:roc::rocblas> )

--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -1,31 +1,9 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2020 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- *all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_CONV_FIN_HPP
 #define GUARD_CONV_FIN_HPP
+
 #include "base64.hpp"
 #include "error.hpp"
 #include "fin.hpp"
@@ -54,7 +32,6 @@
 #include <miopen/nogpu/handle_impl.hpp>
 #endif
 
-#include <boost/range/adaptor/sliced.hpp>
 namespace fs = miopen::fs;
 
 #include <algorithm>
@@ -66,6 +43,7 @@ namespace fs = miopen::fs;
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <numeric>
+#include <ranges>
 #include <sstream>
 #include <type_traits>
 #include <vector>
@@ -1372,7 +1350,7 @@ std::vector<int> ConvFin<Tgpu, Tref>::GetInputTensorLengths()
     in_lens[0] = command["batchsize"];
     in_lens[1] = command["in_channels"];
 
-    auto in_spatial_lens = boost::adaptors::slice(in_lens, 2, 2 + spatial_dim);
+    auto in_spatial_lens = in_lens | std::views::drop(2) | std::views::take(spatial_dim);
 
     if(spatial_dim == 2)
     {
@@ -1406,7 +1384,7 @@ std::vector<int> ConvFin<Tgpu, Tref>::GetWeightTensorLengths()
     int spatial_dim = command["spatial_dim"];
     wei_lens.resize(2 + spatial_dim);
 
-    auto wei_spatial_lens = boost::adaptors::slice(wei_lens, 2, 2 + spatial_dim);
+    auto wei_spatial_lens = wei_lens | std::views::drop(2) | std::views::take(spatial_dim);
 
     int group_count = std::max(int(command["group_count"]), 1);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 include(googletest)
 enable_testing()
 include(GoogleTest)
@@ -14,7 +17,7 @@ function(add_gtest TEST_NAME)
   target_include_directories(test_${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/include  
 	  					       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include>)
   target_compile_definitions(test_${TEST_NAME} PUBLIC TEST_RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/")
-  target_link_libraries(test_${TEST_NAME} gtest_main MIOpen ${Boost_LIBRARIES} hip::host $<BUILD_INTERFACE:roc::rocblas>)
+  target_link_libraries(test_${TEST_NAME} gtest_main MIOpen hip::host $<BUILD_INTERFACE:roc::rocblas>)
   gtest_discover_tests(test_${TEST_NAME})
   if(HAS_LIB_STD_FILESYSTEM)
     target_link_libraries(test_${TEST_NAME} stdc++fs)


### PR DESCRIPTION
## Motivation

Remove Boost library usage

## Technical Details

Usage of boost::adaptors::slice has been replaced with standard C++20 ranges.

## Test Plan & Test Result

CI shall pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
