### PR TITLE
Remove Boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,11 +157,6 @@ if(CMAKE_CXX_COMPILER MATCHES ".*hcc")
     endif()
 endif()
 
-option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)
-set(BOOST_COMPONENTS filesystem system)
-add_definitions(-DBOOST_ALL_NO_LIB=1)
-find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-
 find_path(HALF_INCLUDE_DIR half.hpp HINTS ${CMAKE_INSTALL_PREFIX}
     PATH_SUFFIXES include include/half)
 message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ configure_file("${PROJECT_SOURCE_DIR}/src/include/config.h.in" "${PROJECT_BINARY
 include_directories(include "${PROJECT_BINARY_DIR}/src/include")
 add_executable(fin main.cpp fin.cpp base64.cpp)
 target_compile_definitions( fin PRIVATE -D__HIP_PLATFORM_HCC__=1 )
-target_link_libraries(fin MIOpen ${Boost_LIBRARIES} hip::host)
+target_link_libraries(fin MIOpen hip::host)
 target_link_libraries(fin ${CMAKE_THREAD_LIBS_INIT})
 if(rocblas_FOUND)
     target_link_libraries( fin $<BUILD_INTERFACE:roc::rocblas> )

--- a/src/include/conv_fin.hpp
+++ b/src/include/conv_fin.hpp
@@ -54,7 +54,7 @@
 #include <miopen/nogpu/handle_impl.hpp>
 #endif
 
-#include <boost/range/adaptor/sliced.hpp>
+#include <span>
 namespace fs = miopen::fs;
 
 #include <algorithm>
@@ -1351,7 +1351,7 @@ std::vector<int> ConvFin<Tgpu, Tref>::GetInputTensorLengths()
     in_lens[0] = command["batchsize"];
     in_lens[1] = command["in_channels"];
 
-    auto in_spatial_lens = boost::adaptors::slice(in_lens, 2, 2 + spatial_dim);
+    auto in_spatial_lens = std::span<int>(in_lens.data() + 2, spatial_dim);
 
     if(spatial_dim == 2)
     {
@@ -1385,7 +1385,7 @@ std::vector<int> ConvFin<Tgpu, Tref>::GetWeightTensorLengths()
     int spatial_dim = command["spatial_dim"];
     wei_lens.resize(2 + spatial_dim);
 
-    auto wei_spatial_lens = boost::adaptors::slice(wei_lens, 2, 2 + spatial_dim);
+    auto wei_spatial_lens = std::span<int>(wei_lens.data() + 2, spatial_dim);
 
     int group_count = std::max(int(command["group_count"]), 1);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ function(add_gtest TEST_NAME)
   target_include_directories(test_${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/include  
 	  					       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include>)
   target_compile_definitions(test_${TEST_NAME} PUBLIC TEST_RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/")
-  target_link_libraries(test_${TEST_NAME} gtest_main MIOpen ${Boost_LIBRARIES} hip::host $<BUILD_INTERFACE:roc::rocblas>)
+  target_link_libraries(test_${TEST_NAME} gtest_main MIOpen hip::host $<BUILD_INTERFACE:roc::rocblas>)
   gtest_discover_tests(test_${TEST_NAME})
   if(HAS_LIB_STD_FILESYSTEM)
     target_link_libraries(test_${TEST_NAME} stdc++fs)


### PR DESCRIPTION
- Replace boost::adaptors::slice with std::span in conv_fin.hpp
- Remove find_package(Boost) and Boost_LIBRARIES from fin, fin/src, and fin/tests CMakeLists

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
